### PR TITLE
Use os.path instead of pathlib

### DIFF
--- a/smdebug_rulesconfig/_utils.py
+++ b/smdebug_rulesconfig/_utils.py
@@ -1,11 +1,11 @@
 import json
 import os
-from pathlib import Path
 from ._constants import RULE_CONFIG_FILE, RULE_GROUPS_CONFIG_FILE, COLLECTION_CONFIG_FILE
 
 def _get_rule_config(rule_name):
     rule_config = None
-    config_file_path = str(Path(__file__).parent.absolute()) + "/" + RULE_CONFIG_FILE
+
+    config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/" + RULE_CONFIG_FILE
 
     if os.path.exists(config_file_path):
         with open(config_file_path) as json_data:
@@ -16,7 +16,9 @@ def _get_rule_config(rule_name):
 
 def _get_rule_list(framework, type):
     rules_list = []
-    config_file_path = str(Path(__file__).parent.absolute()) + "/" + RULE_GROUPS_CONFIG_FILE
+
+    config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/" + RULE_GROUPS_CONFIG_FILE
+
     if os.path.exists(config_file_path):
         with open(config_file_path) as json_data:
             configs = json.load(json_data)
@@ -27,7 +29,8 @@ def _get_rule_list(framework, type):
 
 def _get_config_for_group(rules):
     rules_config = []
-    config_file_path = str(Path(__file__).parent.absolute()) + "/" + RULE_CONFIG_FILE
+
+    config_file_path = os.path.dirname(os.path.abspath(__file__)) + "/" + RULE_CONFIG_FILE
 
     if os.path.exists(config_file_path):
         with open(config_file_path) as json_data:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
pathlib is not compatible with Py2. using os.path instead.

Testing:
```
> python2.7
Python 2.7.15 |Anaconda, Inc.| (default, May  1 2018, 18:37:05) 
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import smdebug_rulesconfig
>>> smdebug_rulesconfig._1PRules.all_zero()
{u'DebugRuleConfiguration': {u'RuleConfigurationName': u'AllZero', u'RuleParameters': {u'rule_to_invoke': u'AllZero'}}}
>>> smdebug_rulesconfig._1PRules.check_input_images()
{u'DebugRuleConfiguration': {u'RuleConfigurationName': u'CheckInputImages', u'RuleParameters': {u'rule_to_invoke': u'CheckInputImages'}}, u'CollectionConfigurations': [{u'CollectionName': u'input_image', u'CollectionParameters': {u'include_regex': u'.*hybridsequential0_input_0'}}]}
>>> exit()
```

```
python
Python 3.6.5 |Anaconda, Inc.| (default, Apr 26 2018, 08:42:37) 
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import smdebug_rulesconfig
>>> smdebug_rulesconfig._1PRules.all_zero()
{'DebugRuleConfiguration': {'RuleConfigurationName': 'AllZero', 'RuleParameters': {'rule_to_invoke': 'AllZero'}}}
>>> smdebug_rulesconfig._1PRules.vanishing_gradient()
{'DebugRuleConfiguration': {'RuleConfigurationName': 'VanishingGradient', 'RuleParameters': {'rule_to_invoke': 'VanishingGradient'}}, 'CollectionConfigurations': [{'CollectionName': 'gradients'}]}
>>> exit()
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
