### PR TITLE
Set instance type in the rule_config

### DIFF
--- a/smdebug_rulesconfig/rule_config_jsons/ruleConfigs.json
+++ b/smdebug_rulesconfig/rule_config_jsons/ruleConfigs.json
@@ -4,7 +4,8 @@
       "RuleConfigurationName": "VanishingGradient",
       "RuleParameters": {
         "rule_to_invoke": "VanishingGradient"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     },
     "CollectionConfigurations": [
       {
@@ -18,7 +19,8 @@
       "RuleParameters": {
         "rule_to_invoke": "LossNotDecreasing",
         "mode" : "TRAIN"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     },
     "CollectionConfigurations": [
       {
@@ -31,7 +33,8 @@
       "RuleConfigurationName": "WeightUpdateRatio",
       "RuleParameters": {
         "rule_to_invoke": "WeightUpdateRatio"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     },
     "CollectionConfigurations": [
       {
@@ -44,7 +47,8 @@
       "RuleConfigurationName": "CheckInputImages",
       "RuleParameters": {
         "rule_to_invoke": "CheckInputImages"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     },
     "CollectionConfigurations": [
       {
@@ -60,7 +64,8 @@
       "RuleConfigurationName": "DeadRelu",
       "RuleParameters": {
         "rule_to_invoke": "DeadRelu"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     },
     "CollectionConfigurations": [
       {
@@ -76,7 +81,8 @@
       "RuleConfigurationName": "AllZero",
       "RuleParameters": {
         "rule_to_invoke": "AllZero"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     }
   },
   "ExplodingTensor" : {
@@ -84,7 +90,8 @@
       "RuleConfigurationName": "ExplodingTensor",
       "RuleParameters": {
         "rule_to_invoke": "ExplodingTensor"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     }
   },
   "UnchangedTensor" : {
@@ -92,7 +99,8 @@
       "RuleConfigurationName": "UnchangedTensor",
       "RuleParameters": {
         "rule_to_invoke": "UnchangedTensor"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     }
   },
   "SimilarAcrossRuns": {
@@ -100,7 +108,8 @@
       "RuleConfigurationName": "SimilarAcrossRuns",
       "RuleParameters": {
         "rule_to_invoke": "SimilarAcrossRuns"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     }
   },
   "TreeDepth": {
@@ -108,7 +117,8 @@
       "RuleConfigurationName": "TreeDepth",
       "RuleParameters": {
         "rule_to_invoke": "TreeDepth"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     }
   },
   "ClassImbalance": {
@@ -116,7 +126,8 @@
       "RuleConfigurationName": "ClassImbalance",
       "RuleParameters": {
         "rule_to_invoke": "ClassImbalance"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     }
   },
   "Confusion": {
@@ -124,7 +135,8 @@
       "RuleConfigurationName": "Confusion",
       "RuleParameters": {
         "rule_to_invoke": "Confusion"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     }
   },
   "Overfit": {
@@ -132,7 +144,8 @@
       "RuleConfigurationName": "Overfit",
       "RuleParameters": {
         "rule_to_invoke": "Overfit"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     }
   },
   "TensorVariance" : {
@@ -140,7 +153,8 @@
       "RuleConfigurationName": "TensorVariance",
       "RuleParameters": {
         "rule_to_invoke": "TensorVariance"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     }
   },
   "Overtraining": {
@@ -148,7 +162,8 @@
       "RuleConfigurationName": "Overtraining",
       "RuleParameters": {
         "rule_to_invoke": "Overtraining"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     }
   },
   "PoorWeightInitialization" : {
@@ -156,7 +171,8 @@
       "RuleConfigurationName": "PoorWeightInitialization",
       "RuleParameters": {
         "rule_to_invoke": "PoorWeightInitialization"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     },
     "CollectionConfigurations": [
       {
@@ -172,7 +188,8 @@
       "RuleConfigurationName": "SaturatedActivation",
       "RuleParameters": {
         "rule_to_invoke": "SaturatedActivation"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     }
   },
   "NLPSequenceRatio" : {
@@ -180,7 +197,8 @@
       "RuleConfigurationName": "NLPSequenceRatio",
       "RuleParameters": {
         "rule_to_invoke": "NLPSequenceRatio"
-      }
+      },
+      "InstanceType": "ml.t3.medium"
     },
     "CollectionConfigurations": [
       {


### PR DESCRIPTION

We will currently set the instance type to be 'ml.t3.medium'.
This will change as per the recommendation based on the performance tests.


Testing:
1. Built and installed the pip wheel.
2. Ran the commands to fetch the config

186590de8981:~ amollele$ python
Python 3.7.4 (default, Jul  9 2019, 18:14:44) 
[Clang 9.0.0 (clang-900.0.39.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import smdebug_rulesconfig as smd
>>> smd.__dir__()
['__name__', '__doc__', '__package__', '__loader__', '__spec__', '__path__', '__file__', '__cached__', '__builtins__', '_constants', '_utils', 'builtin_rules', 'vanishing_gradient', 'all_zero', 'check_input_images', 'similar_across_runs', 'weight_update_ratio', 'exploding_tensor', 'unchanged_tensor', 'loss_not_decreasing', 'dead_relu', 'confusion', 'class_imbalance', 'overfit', 'tree_depth', 'tensor_variance', 'overtraining', 'poor_weight_initialization', 'saturated_activation', 'nlp_sequence_ratio', '_collections', 'get_collection']
>>> smd.get_collection('weights')
{'CollectionName': 'weights'}
>>> smd.check_input_images()
{'DebugRuleConfiguration': {'RuleConfigurationName': 'CheckInputImages', 'RuleParameters': {'rule_to_invoke': 'CheckInputImages'}, 'InstanceType': 'ml.t3.medium'}, 'CollectionConfigurations': [{'CollectionName': 'input_image', 'CollectionParameters': {'include_regex': '.*hybridsequential0_input_0'}}]}
>>> smd.all_zero()
{'DebugRuleConfiguration': {'RuleConfigurationName': 'AllZero', 'RuleParameters': {'rule_to_invoke': 'AllZero'}, 'InstanceType': 'ml.t3.medium'}}
>>> 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
