### PR TITLE
Revert "Set instance type in the rule_config"

### DIFF
--- a/smdebug_rulesconfig/rule_config_jsons/ruleConfigs.json
+++ b/smdebug_rulesconfig/rule_config_jsons/ruleConfigs.json
@@ -4,8 +4,7 @@
       "RuleConfigurationName": "VanishingGradient",
       "RuleParameters": {
         "rule_to_invoke": "VanishingGradient"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     },
     "CollectionConfigurations": [
       {
@@ -19,8 +18,7 @@
       "RuleParameters": {
         "rule_to_invoke": "LossNotDecreasing",
         "mode" : "TRAIN"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     },
     "CollectionConfigurations": [
       {
@@ -33,8 +31,7 @@
       "RuleConfigurationName": "WeightUpdateRatio",
       "RuleParameters": {
         "rule_to_invoke": "WeightUpdateRatio"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     },
     "CollectionConfigurations": [
       {
@@ -47,8 +44,7 @@
       "RuleConfigurationName": "CheckInputImages",
       "RuleParameters": {
         "rule_to_invoke": "CheckInputImages"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     },
     "CollectionConfigurations": [
       {
@@ -64,8 +60,7 @@
       "RuleConfigurationName": "DeadRelu",
       "RuleParameters": {
         "rule_to_invoke": "DeadRelu"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     },
     "CollectionConfigurations": [
       {
@@ -81,8 +76,7 @@
       "RuleConfigurationName": "AllZero",
       "RuleParameters": {
         "rule_to_invoke": "AllZero"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     }
   },
   "ExplodingTensor" : {
@@ -90,8 +84,7 @@
       "RuleConfigurationName": "ExplodingTensor",
       "RuleParameters": {
         "rule_to_invoke": "ExplodingTensor"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     }
   },
   "UnchangedTensor" : {
@@ -99,8 +92,7 @@
       "RuleConfigurationName": "UnchangedTensor",
       "RuleParameters": {
         "rule_to_invoke": "UnchangedTensor"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     }
   },
   "SimilarAcrossRuns": {
@@ -108,8 +100,7 @@
       "RuleConfigurationName": "SimilarAcrossRuns",
       "RuleParameters": {
         "rule_to_invoke": "SimilarAcrossRuns"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     }
   },
   "TreeDepth": {
@@ -117,8 +108,7 @@
       "RuleConfigurationName": "TreeDepth",
       "RuleParameters": {
         "rule_to_invoke": "TreeDepth"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     }
   },
   "ClassImbalance": {
@@ -126,8 +116,7 @@
       "RuleConfigurationName": "ClassImbalance",
       "RuleParameters": {
         "rule_to_invoke": "ClassImbalance"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     }
   },
   "Confusion": {
@@ -135,8 +124,7 @@
       "RuleConfigurationName": "Confusion",
       "RuleParameters": {
         "rule_to_invoke": "Confusion"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     }
   },
   "Overfit": {
@@ -144,8 +132,7 @@
       "RuleConfigurationName": "Overfit",
       "RuleParameters": {
         "rule_to_invoke": "Overfit"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     }
   },
   "TensorVariance" : {
@@ -153,8 +140,7 @@
       "RuleConfigurationName": "TensorVariance",
       "RuleParameters": {
         "rule_to_invoke": "TensorVariance"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     }
   },
   "Overtraining": {
@@ -162,8 +148,7 @@
       "RuleConfigurationName": "Overtraining",
       "RuleParameters": {
         "rule_to_invoke": "Overtraining"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     }
   },
   "PoorWeightInitialization" : {
@@ -171,8 +156,7 @@
       "RuleConfigurationName": "PoorWeightInitialization",
       "RuleParameters": {
         "rule_to_invoke": "PoorWeightInitialization"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     },
     "CollectionConfigurations": [
       {
@@ -188,8 +172,7 @@
       "RuleConfigurationName": "SaturatedActivation",
       "RuleParameters": {
         "rule_to_invoke": "SaturatedActivation"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     }
   },
   "NLPSequenceRatio" : {
@@ -197,8 +180,7 @@
       "RuleConfigurationName": "NLPSequenceRatio",
       "RuleParameters": {
         "rule_to_invoke": "NLPSequenceRatio"
-      },
-      "InstanceType": "ml.t3.medium"
+      }
     },
     "CollectionConfigurations": [
       {


### PR DESCRIPTION
Reverts awslabs/sagemaker-debugger-rulesconfig#8
We do not require to set the instance typle