### PR TITLE
Remove mode set for LossNotDecreasing rule

### DIFF
--- a/smdebug_rulesconfig/rule_config_jsons/ruleConfigs.json
+++ b/smdebug_rulesconfig/rule_config_jsons/ruleConfigs.json
@@ -16,8 +16,7 @@
     "DebugRuleConfiguration": {
       "RuleConfigurationName": "LossNotDecreasing",
       "RuleParameters": {
-        "rule_to_invoke": "LossNotDecreasing",
-        "mode" : "TRAIN"
+        "rule_to_invoke": "LossNotDecreasing"
       }
     },
     "CollectionConfigurations": [


### PR DESCRIPTION
*Description of changes:*
The rule is capable of determining the mode. And passing train here does not work for xgboost. Train is not the loss we track anyway. So setting this here is problematic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
