### PR TITLE
Correcting import in the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Amazon SageMaker Debugger Rulesconfig package can be used with Amazon SageMaker 
 Example: Vanilla builtin rule without customization
 
 ```
-from sagemaker.debug import Rule
+from sagemaker.debugger import Rule
 from smdebug_rulesconfig import vanishing_gradient
 
 my_estimator = Estimator(


### PR DESCRIPTION
The correct module is `sagemaker.debugger` and not `sagemaker.debug`

*Description of changes:*
Correcting the imported module in README example.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
