### PR TITLE
Fixing the wrong initialization of Estimator in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ my_estimator = Estimator(
                 )
             ],
         )
-    ],
-    wait=False
+    ]
 )
 ```
 
@@ -65,8 +64,7 @@ my_estimator = Estimator(
                 get_collection("weights")
             ],
         )
-    ],
-    wait=False
+    ]
 )
 ```
 


### PR DESCRIPTION
`wait=False` is not an attribute of the `Estimator` class but a parameter in `fit()`

*Description of changes:*
Removing `wait=False` in the Estimator's initialization

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
