### PR TITLE
Enable __version__

### DIFF
--- a/smdebug_rulesconfig/__init__.py
+++ b/smdebug_rulesconfig/__init__.py
@@ -35,3 +35,6 @@ from .profiler_rules.rules import (
     ProfilerReport,
     StepOutlier,
 )
+
+# Local
+from ._version import __version__


### PR DESCRIPTION
*Issue #, if available:*
- We couldn't previously run `smdebug_rulesconfig.__version__`

*Description of changes:*
- Added an import line to `__init__.py`

*Testing:*:

- Manually tested this branch with:
```
>>> import smdebug_rulesconfig
>>> print(smdebug_rulesconfig.__version__)
1.0.0

```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
