### PR TITLE
Add Opt Out Telemetry Flag To Profiler Rule

### DIFF
--- a/smdebug_rulesconfig/profiler_rules/rules.py
+++ b/smdebug_rulesconfig/profiler_rules/rules.py
@@ -4,6 +4,7 @@ from smdebug_rulesconfig.profiler_rules.utils import (
     invalid_key_format_error,
     invalid_rule_error,
     invalid_param_error,
+    validate_boolean,
     validate_percentile,
     validate_positive_integer,
 )
@@ -266,7 +267,7 @@ class StepOutlier(ProfilerRuleBase):
 
 
 class ProfilerReport(ProfilerRuleBase):
-    def __init__(self, **rule_parameters):
+    def __init__(self, opt_out_telemetry=False, **rule_parameters):
         """
         This rule will create a profiler report after invoking all of the rules. The parameters
         used in any of these rules can be customized by following this naming scheme:
@@ -285,6 +286,8 @@ class ProfilerReport(ProfilerRuleBase):
         rule_classes = ProfilerReport.get_rules()
         rule_names = str([rule.__name__ for rule in rule_classes]).strip("[]")
         rule_classes_by_name = {rule.__name__.lower(): rule for rule in rule_classes}
+        validate_boolean(self.__class__.__name__, "opt_out_telemetry", opt_out_telemetry)
+        self.opt_out_telemetry = opt_out_telemetry
 
         formatted_rule_parameters = {}
 
@@ -306,7 +309,9 @@ class ProfilerReport(ProfilerRuleBase):
             formatted_key = f"{rule_class.__name__}_{parameter_name}"
             formatted_rule_parameters[formatted_key] = val
 
-        super().__init__(custom_rule_parameters=formatted_rule_parameters)
+        super().__init__(
+            opt_out_telemetry=opt_out_telemetry, custom_rule_parameters=formatted_rule_parameters
+        )
 
     @classmethod
     def get_rules(cls):

--- a/smdebug_rulesconfig/profiler_rules/rules.py
+++ b/smdebug_rulesconfig/profiler_rules/rules.py
@@ -287,7 +287,6 @@ class ProfilerReport(ProfilerRuleBase):
         rule_names = str([rule.__name__ for rule in rule_classes]).strip("[]")
         rule_classes_by_name = {rule.__name__.lower(): rule for rule in rule_classes}
         validate_boolean(self.__class__.__name__, "opt_out_telemetry", opt_out_telemetry)
-        self.opt_out_telemetry = opt_out_telemetry
 
         formatted_rule_parameters = {}
 

--- a/smdebug_rulesconfig/profiler_rules/utils.py
+++ b/smdebug_rulesconfig/profiler_rules/utils.py
@@ -1,3 +1,4 @@
+invalid_boolean_error = "{0} accepts only boolean values for {1} "
 invalid_key_format_error = "Key {0} does not follow naming scheme: <rule_name>_<parameter_name>"
 invalid_rule_error = "{0} is an invalid rule name! Accepted case insensitive rule names are: {1}"
 invalid_param_error = "{0} is an invalid parameter name! Accepted parameter names for {1} are: {2}"
@@ -11,3 +12,7 @@ def validate_positive_integer(rule_name, key, val):
 
 def validate_percentile(rule_name, key, val):
     assert 0 <= val <= 100, invalid_percentile_error.format(rule_name, key)
+
+
+def validate_boolean(rule_name, key, val):
+    assert isinstance(val, bool), invalid_boolean_error.format(rule_name, key)

--- a/tests/core/profiler_rules/test_profiler_report_rule.py
+++ b/tests/core/profiler_rules/test_profiler_report_rule.py
@@ -23,6 +23,7 @@ def test_default_profiler_report_rule():
     assert rule.rule_parameters == {
         "rule_to_invoke": ProfilerReport.__name__,
         "custom_rule_parameters": {},
+        "opt_out_telemetry": False
     }
 
 
@@ -52,6 +53,7 @@ def test_valid_profiler_report_rule_custom_params():
     assert rule.rule_parameters == {
         "rule_to_invoke": ProfilerReport.__name__,
         "custom_rule_parameters": {"CPUBottleneck_threshold": 30},
+        "opt_out_telemetry": False
     }
 
     # case of parameter doesn't matter
@@ -60,6 +62,7 @@ def test_valid_profiler_report_rule_custom_params():
     assert rule.rule_parameters == {
         "rule_to_invoke": ProfilerReport.__name__,
         "custom_rule_parameters": {"CPUBottleneck_threshold": 20},
+        "opt_out_telemetry": False
     }
 
 

--- a/tests/core/profiler_rules/test_profiler_report_rule.py
+++ b/tests/core/profiler_rules/test_profiler_report_rule.py
@@ -3,6 +3,7 @@ import inspect
 
 from smdebug_rulesconfig.profiler_rules.rules import CPUBottleneck, ProfilerReport
 from smdebug_rulesconfig.profiler_rules.utils import (
+    invalid_boolean_error,
     invalid_key_format_error,
     invalid_param_error,
     invalid_rule_error,
@@ -23,6 +24,26 @@ def test_default_profiler_report_rule():
         "rule_to_invoke": ProfilerReport.__name__,
         "custom_rule_parameters": {},
     }
+
+
+def test_opt_out_flag_for_profiler_report_rule():
+    # Default Case
+    rule = ProfilerReport()
+    assert not rule.opt_out_telemetry
+
+    # Explicit Opt In
+    rule = ProfilerReport(opt_out_telemetry=False)
+    assert not rule.opt_out_telemetry
+
+    # Explicit Opt Out
+    rule = ProfilerReport(opt_out_telemetry=True)
+    assert rule.opt_out_telemetry
+
+    # Invalid Input
+    with pytest.raises(
+        AssertionError, match=invalid_boolean_error.format("ProfilerReport", "opt_out_telemetry")
+    ):
+        ProfilerReport(opt_out_telemetry="False")
 
 
 def test_valid_profiler_report_rule_custom_params():

--- a/tests/core/profiler_rules/test_profiler_report_rule.py
+++ b/tests/core/profiler_rules/test_profiler_report_rule.py
@@ -23,7 +23,7 @@ def test_default_profiler_report_rule():
     assert rule.rule_parameters == {
         "rule_to_invoke": ProfilerReport.__name__,
         "custom_rule_parameters": {},
-        "opt_out_telemetry": False
+        "opt_out_telemetry": False,
     }
 
 
@@ -53,7 +53,7 @@ def test_valid_profiler_report_rule_custom_params():
     assert rule.rule_parameters == {
         "rule_to_invoke": ProfilerReport.__name__,
         "custom_rule_parameters": {"CPUBottleneck_threshold": 30},
-        "opt_out_telemetry": False
+        "opt_out_telemetry": False,
     }
 
     # case of parameter doesn't matter
@@ -62,7 +62,7 @@ def test_valid_profiler_report_rule_custom_params():
     assert rule.rule_parameters == {
         "rule_to_invoke": ProfilerReport.__name__,
         "custom_rule_parameters": {"CPUBottleneck_threshold": 20},
-        "opt_out_telemetry": False
+        "opt_out_telemetry": False,
     }
 
 

--- a/tests/core/profiler_rules/test_profiler_report_rule.py
+++ b/tests/core/profiler_rules/test_profiler_report_rule.py
@@ -54,7 +54,8 @@ def test_opt_out_flag_for_profiler_report_rule():
 
     # Invalid Input
     with pytest.raises(
-        AssertionError, match=invalid_boolean_error.format(ProfilerReport.__name__, "opt_out_telemetry")
+        AssertionError,
+        match=invalid_boolean_error.format(ProfilerReport.__name__, "opt_out_telemetry"),
     ):
         ProfilerReport(opt_out_telemetry="False")
 

--- a/tests/core/profiler_rules/test_profiler_report_rule.py
+++ b/tests/core/profiler_rules/test_profiler_report_rule.py
@@ -30,19 +30,31 @@ def test_default_profiler_report_rule():
 def test_opt_out_flag_for_profiler_report_rule():
     # Default Case
     rule = ProfilerReport()
-    assert not rule.opt_out_telemetry
+    assert rule.rule_parameters == {
+        "rule_to_invoke": ProfilerReport.__name__,
+        "custom_rule_parameters": {},
+        "opt_out_telemetry": False,
+    }
 
     # Explicit Opt In
     rule = ProfilerReport(opt_out_telemetry=False)
-    assert not rule.opt_out_telemetry
+    assert rule.rule_parameters == {
+        "rule_to_invoke": ProfilerReport.__name__,
+        "custom_rule_parameters": {},
+        "opt_out_telemetry": False,
+    }
 
     # Explicit Opt Out
     rule = ProfilerReport(opt_out_telemetry=True)
-    assert rule.opt_out_telemetry
+    assert rule.rule_parameters == {
+        "rule_to_invoke": ProfilerReport.__name__,
+        "custom_rule_parameters": {},
+        "opt_out_telemetry": True,
+    }
 
     # Invalid Input
     with pytest.raises(
-        AssertionError, match=invalid_boolean_error.format("ProfilerReport", "opt_out_telemetry")
+        AssertionError, match=invalid_boolean_error.format(ProfilerReport.__name__, "opt_out_telemetry")
     ):
         ProfilerReport(opt_out_telemetry="False")
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add the ability for customers to opt out of profiler telemetry which is collected by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
