### PR TITLE
Move tests off from the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def build_rule_config_package(version):
         description="SMDebug RulesConfig",
         long_description=long_description,
         url="https://github.com/awslabs/sagemaker-debugger-rulesconfig",
-        packages=setuptools.find_packages(),
+        packages=['smdebug_rulesconfig'],
         package_data={"smdebug_rulesconfig": ["debugger_rules/rule_config_jsons/*.json"]},
         classifiers=[
             "Programming Language :: Python :: 3",


### PR DESCRIPTION
*Issue #, if available:*
Currently, when building the package, this is moving the tests as well, so when you install the package, it will also install a tests packages which are unnecessary and creates issues with modules from other repos.

issue #38 

*Description of changes:*
Only creates the package with the necessary module

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
