### PR TITLE
Update email regexp

### DIFF
--- a/smdebug_rulesconfig/actions/utils.py
+++ b/smdebug_rulesconfig/actions/utils.py
@@ -3,7 +3,7 @@ import json
 
 
 TRAINING_JOB_PREFIX_REGEX = "^[A-Za-z0-9\-]+$"
-EMAIL_ADDRESS_REGEX = "^[a-z0-9]+[@]\w+[.]\w{2,3}$"
+EMAIL_ADDRESS_REGEX = r"^\w+(?:[\.-]?\w+)*@\w+(?:[\.-]?\w+)*(?:\.\w{2,3})+$"
 PHONE_NUMBER_REGEX = "^\+\d{1,15}$"
 
 

--- a/tests/core/actions/test_utils.py
+++ b/tests/core/actions/test_utils.py
@@ -1,0 +1,23 @@
+import pytest
+
+from smdebug_rulesconfig.actions.utils import validate_email_address
+
+
+@pytest.fixture
+def key():
+    return "email_address"
+
+
+def test_validate_email_address(key):
+    """
+    Validates correct and incorrect email addresses passed to `validate_email_address` function.
+    """
+    with pytest.raises(ValueError):
+        validate_email_address(key, 123)
+
+    with pytest.raises(ValueError):
+        validate_email_address(key, "abc@abc")
+
+    assert validate_email_address(key, "abc@abc.com") is None
+
+    assert validate_email_address(key, "abc@abc.def.com") is None


### PR DESCRIPTION
Issue #37 

Updated email validation regexp - now it is allowed to pass emails like `abc@abc.def.com`; covered `validate_email_address` function by tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
